### PR TITLE
improve import export compat

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,5 +1,5 @@
 const CONSTANTS = {
-  METEOR_ROOT_DIRECTORY: "/home/minhna/WORKS/Mike/settler/se2-admin",
+  METEOR_ROOT_DIRECTORY: "/please/configure/constants/",
 };
 
 export default CONSTANTS;

--- a/transform-export-async-function.ts
+++ b/transform-export-async-function.ts
@@ -17,7 +17,7 @@ import {
   file,
 } from "jscodeshift";
 
-const tsParser = require("jscodeshift/parser/ts");
+const tsParser = require("jscodeshift/parser/babel5Compat");
 
 const debug = require("debug")("transform:export-async-script");
 const debug2 = require("debug")("transform:print:export-async-script");


### PR DESCRIPTION
Some updates were made to improve the range of `import` and `export` statements supported.

It's still incomplete - it doesn't support `ExportAllDeclaration` (`export * from './other'`).

However, the improvements do support some `export ... from './other'` statements, and import namespaces.